### PR TITLE
Подправка требований для python 3.4+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 twisted
-enum
 pyOpenSSL
 smpp.pdu


### PR DESCRIPTION
В python 3.4 ввели тип enum, поэтому установка библиотеки ломает установку